### PR TITLE
Update zod to v4 and patch compatibility

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -49,7 +49,7 @@
     "@prisma/generator-helper": "^6.3.0",
     "code-block-writer": "^12.0.0",
     "lodash": "^4.17.21",
-    "zod": "^3.24.1"
+    "zod": "^4.0.0"
   },
   "peerDependencies": {
     "@prisma/client": "^4.x.x || ^5.x.x || ^6.x.x",

--- a/packages/generator/src/classes/extendedDMMFInputType.ts
+++ b/packages/generator/src/classes/extendedDMMFInputType.ts
@@ -189,7 +189,7 @@ export class ExtendedDMMFInputType
       decimalJSInstalled && this.isDecimalField
         ? `import Decimal from 'decimal.js';`
         : '';
-    const zodImport = "import { z } from 'zod';";
+    const zodImport = "import { z } from 'zod/v4';";
 
     const fieldImports = [
       prismaImport,

--- a/packages/generator/src/classes/extendedDMMFSchemaField.ts
+++ b/packages/generator/src/classes/extendedDMMFSchemaField.ts
@@ -188,7 +188,7 @@ export class ExtendedDMMFSchemaField
     const { prismaClientPath } = this.generatorConfig;
     const prismaImport = `import type { Prisma } from '${prismaClientPath}';`;
 
-    const imports: string[] = ["import { z } from 'zod';", prismaImport];
+    const imports: string[] = ["import { z } from 'zod/v4';", prismaImport];
 
     if (this.writeIncludeArg) {
       imports.push(

--- a/packages/generator/src/functions/contentWriters/writeArgs.ts
+++ b/packages/generator/src/functions/contentWriters/writeArgs.ts
@@ -16,7 +16,7 @@ export const writeArgs = (
     dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', prismaClientPath);
     writeImport(
       `{ ${model.name}SelectSchema }`,

--- a/packages/generator/src/functions/contentWriters/writeCountArgs.ts
+++ b/packages/generator/src/functions/contentWriters/writeCountArgs.ts
@@ -13,7 +13,7 @@ export const writeCountArgs = (
     dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', prismaClientPath);
     writeImport(
       `{ ${model.name}CountOutputTypeSelectSchema }`,

--- a/packages/generator/src/functions/contentWriters/writeCountSelect.ts
+++ b/packages/generator/src/functions/contentWriters/writeCountSelect.ts
@@ -16,7 +16,7 @@ export const writeCountSelect = (
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', prismaClientPath);
   }
 

--- a/packages/generator/src/functions/contentWriters/writeCustomEnum.ts
+++ b/packages/generator/src/functions/contentWriters/writeCustomEnum.ts
@@ -12,7 +12,7 @@ export const writeCustomEnum = (
   const { useMultipleFiles } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
   }
 
   writer.blankLine().write(`export const ${name}Schema = z.enum([`);

--- a/packages/generator/src/functions/contentWriters/writeDecimalJsLike.ts
+++ b/packages/generator/src/functions/contentWriters/writeDecimalJsLike.ts
@@ -8,7 +8,7 @@ export const writeDecimalJsLike = ({
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', `${prismaClientPath}`);
   }
 

--- a/packages/generator/src/functions/contentWriters/writeDecimalJsLikeList.ts
+++ b/packages/generator/src/functions/contentWriters/writeDecimalJsLikeList.ts
@@ -8,7 +8,7 @@ export const writeDecimalJsLikeList = ({
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', `${prismaClientPath}`);
   }
 

--- a/packages/generator/src/functions/contentWriters/writeInclude.ts
+++ b/packages/generator/src/functions/contentWriters/writeInclude.ts
@@ -12,7 +12,7 @@ export const writeInclude = (
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', prismaClientPath);
     writeImportSet(model.includeImports);
   }

--- a/packages/generator/src/functions/contentWriters/writeInputJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeInputJsonValue.ts
@@ -8,7 +8,7 @@ export const writeInputJsonValue = ({
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('{ Prisma }', prismaClientPath);
   }
 

--- a/packages/generator/src/functions/contentWriters/writeJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeJsonValue.ts
@@ -8,7 +8,7 @@ export const writeJsonValue = ({
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', prismaClientPath);
   }
 

--- a/packages/generator/src/functions/contentWriters/writeModelOrType.ts
+++ b/packages/generator/src/functions/contentWriters/writeModelOrType.ts
@@ -23,7 +23,7 @@ export const writeModelOrType = (
   const { useMultipleFiles, createRelationValuesTypes } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImportSet(model.imports);
 
     if (createRelationValuesTypes && model.hasRelationFields) {

--- a/packages/generator/src/functions/contentWriters/writeNullableJsonValue.ts
+++ b/packages/generator/src/functions/contentWriters/writeNullableJsonValue.ts
@@ -8,7 +8,7 @@ export const writeNullableJsonValue = ({
   const { useMultipleFiles } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('transformJsonNull', './transformJsonNull');
     writeImport('JsonValueSchema', './JsonValueSchema');
   }

--- a/packages/generator/src/functions/contentWriters/writePrismaEnum.ts
+++ b/packages/generator/src/functions/contentWriters/writePrismaEnum.ts
@@ -12,7 +12,7 @@ export const writePrismaEnum = (
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
   }
 
   if (useNativeEnum) {

--- a/packages/generator/src/functions/contentWriters/writeSelect.ts
+++ b/packages/generator/src/functions/contentWriters/writeSelect.ts
@@ -12,7 +12,7 @@ export const writeSelect = (
   const { useMultipleFiles, prismaClientPath } = dmmf.generatorConfig;
 
   if (useMultipleFiles && !getSingleFileContent) {
-    writeImport('{ z }', 'zod');
+    writeImport('{ z }', 'zod/v4');
     writeImport('type { Prisma }', prismaClientPath);
     writeImportSet(model.selectImports);
   }

--- a/packages/generator/src/functions/writeSingleFileImportStatements.ts
+++ b/packages/generator/src/functions/writeSingleFileImportStatements.ts
@@ -9,7 +9,7 @@ export const writeSingleFileImportStatements: WriteStatements = (
   { writer, writeImport },
 ) => {
   const { prismaClientPath, decimalJSInstalled } = dmmf.generatorConfig;
-  writeImport('{ z }', 'zod');
+  writeImport('{ z }', 'zod/v4');
 
   // Prisma should primarily be imported as a type, but if there are json fields,
   // we need to import the whole namespace because the null transformation

--- a/packages/generator/src/generatorHandler.ts
+++ b/packages/generator/src/generatorHandler.ts
@@ -1,5 +1,5 @@
 import { generatorHandler } from '@prisma/generator-helper';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 import { DirectoryHelper, ExtendedDMMF } from './classes';
 import { generateMultipleFiles } from './generateMultipleFiles';

--- a/packages/generator/src/schemas/generatorConfigSchema.ts
+++ b/packages/generator/src/schemas/generatorConfigSchema.ts
@@ -1,5 +1,5 @@
 import { PrismaVersionSchema } from '../utils';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 ////////////////////////////////////////////////
 // UTILS

--- a/packages/generator/src/schemas/generatorConfigSchema.ts
+++ b/packages/generator/src/schemas/generatorConfigSchema.ts
@@ -2,95 +2,43 @@ import { PrismaVersionSchema } from '../utils';
 import { z } from 'zod';
 
 ////////////////////////////////////////////////
+// UTILS
+/////////////////////////////////////////////////
+
+// Helper to convert optional string ("true" | "false") to boolean with a default value
+const boolFromString = (defaultValue: boolean) =>
+  z
+    .string()
+    .optional()
+    .transform((val) => val === 'true')
+    .default(defaultValue);
+
+////////////////////////////////////////////////
 // SCHEMA
 /////////////////////////////////////////////////
 
 export const configSchema = z.object({
-  useMultipleFiles: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
-  writeBarrelFiles: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  createInputTypes: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  createModelTypes: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  createOptionalDefaultValuesTypes: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
-  createRelationValuesTypes: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
-  createPartialTypes: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
-  addInputTypeValidation: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  addIncludeType: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  addSelectType: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  validateWhereUniqueInput: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  useDefaultValidators: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  coerceDate: z
-    .string()
-    .optional()
-    .default('true')
-    .transform((val) => val === 'true'),
-  writeNullishInModelTypes: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
+  useMultipleFiles: boolFromString(false),
+  writeBarrelFiles: boolFromString(true),
+  createInputTypes: boolFromString(true),
+  createModelTypes: boolFromString(true),
+  createOptionalDefaultValuesTypes: boolFromString(false),
+  createRelationValuesTypes: boolFromString(false),
+  createPartialTypes: boolFromString(false),
+  addInputTypeValidation: boolFromString(true),
+  addIncludeType: boolFromString(true),
+  addSelectType: boolFromString(true),
+  validateWhereUniqueInput: boolFromString(true),
+  useDefaultValidators: boolFromString(true),
+  coerceDate: boolFromString(true),
+  writeNullishInModelTypes: boolFromString(false),
   /**
    * @deprecated This option is deprecated. Zod implemented a fix for this issue.
    */
-  useTypeAssertions: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
+  useTypeAssertions: boolFromString(false),
   prismaClientPath: z.string().default('@prisma/client'),
   provider: z.string().optional(),
-  isMongoDb: z
-    .string()
-    .optional()
-    .default('false')
-    .transform((val) => val === 'true'),
+  isMongoDb: boolFromString(false),
   inputTypePath: z.string().optional().default('inputTypeSchemas'), // currently only used internally
   outputTypePath: z.string().optional().default('outputTypeSchemas'), // currently only used internally
   prismaVersion: PrismaVersionSchema.optional(),

--- a/packages/generator/src/utils/getPrismaDbProvider.ts
+++ b/packages/generator/src/utils/getPrismaDbProvider.ts
@@ -1,5 +1,5 @@
 import { GeneratorOptions } from '@prisma/generator-helper';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const providerSchema = z.string();
 

--- a/packages/generator/src/utils/getPrismaVersion.ts
+++ b/packages/generator/src/utils/getPrismaVersion.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 export const PrismaVersionSchema = z.object({
   major: z.number(),

--- a/packages/generator/src/utils/skipGenerator.ts
+++ b/packages/generator/src/utils/skipGenerator.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 /////////////////////////////////////////////////
 // SCHEMAS

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -32,7 +32,7 @@
     "ts-node-dev": "^2.0.0",
     "validator": "^13.12.0",
     "vitest": "^0.25.8",
-    "zod": "^3.24.1",
+    "zod": "^4.0.0",
     "zod-prisma-types": "workspace:*"
   }
 }

--- a/packages/usage/tests/implementations/decimalSchema.ts
+++ b/packages/usage/tests/implementations/decimalSchema.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { DecimalJsLike } from '@prisma/client/runtime/library';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
   DecimalJsLikeSchema,
   isValidDecimalInput,


### PR DESCRIPTION
Update `zod-prisma-types` to be compatible with Zod v4 by adjusting generator config parsing for new `.default()` semantics.

Zod v4 changed the behavior of `.default()`, causing it to short-circuit before transformations. This required reordering the `transform` and `default` calls for boolean string flags in the generator config schema to ensure correct parsing and default application.

---
[Slack Thread](https://rubriclab.slack.com/archives/C068RKDHZT6/p1754396616712699?thread_ts=1754396616.712699&cid=C068RKDHZT6)

<a href="https://cursor.com/background-agent?bcId=bc-f15d1910-6d4e-4ce1-9c47-ae7916fcc5d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f15d1910-6d4e-4ce1-9c47-ae7916fcc5d4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

